### PR TITLE
Update credit handling in scrape controller and user model

### DIFF
--- a/api/controllers/scrape.js
+++ b/api/controllers/scrape.js
@@ -200,7 +200,10 @@ const scrapeData = async (req, res) => {
       user.credits.remaining < estimatedCredits
     ) {
       return res.status(402).json({
-        error: "Insufficient credits",
+        // error: "Insufficient credits",
+        error: "Plan upgrade required",
+        message:
+          "Looks like you're doing serious data extraction! Upgrade to Business plan for unlimited extractions and take your lead sourcing to the next level.",
         required: estimatedCredits,
         available: user.credits.remaining,
       });

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -216,7 +216,7 @@ const userSchema = new mongoose.Schema(
     credits: {
       total: {
         type: Number,
-        default: 1000,
+        default: 2000,
       },
       used: {
         type: Number,
@@ -224,7 +224,7 @@ const userSchema = new mongoose.Schema(
       },
       remaining: {
         type: Number,
-        default: 1000,
+        default: 2000,
       },
     },
 
@@ -258,7 +258,8 @@ userSchema.methods.hasUnlimitedAccess = function () {
 // Method to check if user has unlimited extraction (no credit limits)
 userSchema.methods.hasUnlimitedExtraction = function () {
   return (
-    this.plan === "business" ||  this.plan === "free"
+    // this.plan === "business" ||  this.plan === "free"
+    this.plan === "business"
   );
 };
 


### PR DESCRIPTION
- Changed error message for insufficient credits to indicate a plan upgrade is required.
- Increased default credits from 1000 to 2000 in user model for better user experience.
- Adjusted logic for unlimited extraction access to only include business plan.